### PR TITLE
Bugfix/cwe 167429 fix broken link in topaz api doc

### DIFF
--- a/docs/apis/topaz_api.md
+++ b/docs/apis/topaz_api.md
@@ -7,7 +7,7 @@ footer: MIT Licensed | Copyright © 2019 - Compuware
 
 The Topaz API is a Java library that can be used in Java applications to programmatically access and perform operations on datasets and perform JES operations, as well as launch and communicate with their own z/OS programs.
 
-If you are using the Topaz API for plug-ins meant to be run in a Topaz Workbench environment, you should use the [Topaz Workbench SDK](Topaz_Workbench_SDK.md) instead.
+If you are using the Topaz API for plug-ins meant to be run in a Topaz Workbench environment, you should use the [Topaz Workbench SDK](topaz_workbench_sdk.md) instead.
 
 The Compuware Topaz API Specification (Javadoc) can be found <a href="../javadoc/topaz_api/index.html" target="_blank">here</a>.  
 
@@ -76,4 +76,4 @@ org.apache.commons.lang | 2.6.0 | 3rd party language utilities library
 
 ## Coding Examples
 
-[Topaz Workbench API Code Snippets](Topaz_Workbench_API_Code_Snippets.md) provides may useful examples on using the Topaz API. Though a few of the examples are specific for writing plug-ins running in a Topaz Workbench client, most of the examples are also applicable for writing Java applications.
+[Topaz Workbench SDK Code Snippets](topaz_workbench_api_code_snippets.md) provides may useful examples on using the Topaz API. Though a few of the examples are specific for writing plug-ins running in a Topaz Workbench client, most of the examples are also applicable for writing Java applications.

--- a/docs/apis/topaz_workbench_sdk.md
+++ b/docs/apis/topaz_workbench_sdk.md
@@ -5,11 +5,11 @@ footer: MIT Licensed | Copyright © 2018 - Compuware
 
 # Topaz Workbench SDK
 
-The Topaz Workbench SDK includes the Compuware Topaz Workbench and Topaz APIs as well as developer resources such as examples, an examples template, a PassTicket Extension template, code snippets, and Javadoc. The functionality of the SDK provides users with methods to programmatically access and perform operations on datasets and perform JES operations, as well as launch and communicate with their own z/OS programs. The [PassTicket Extension](./Passticket.md) template provides a starter Plug-in project for users to provide an implementation of PassTicket authentication to z/OS.
+The Topaz Workbench SDK includes the Compuware Topaz Workbench and Topaz APIs as well as developer resources such as examples, an examples template, a PassTicket Extension template, code snippets, and Javadoc. The functionality of the SDK provides users with methods to programmatically access and perform operations on datasets and perform JES operations, as well as launch and communicate with their own z/OS programs. The [PassTicket Extension](./passticket.md) template provides a starter Plug-in project for users to provide an implementation of PassTicket authentication to z/OS.
 
 Starting with the **19.5.1 release**, the Compuware Topaz Workbench API consists of two separate layers:
 
-* A base [Topaz API](./Topaz_API.md) that provides APIs to access the mainframe with no dependencies on Topaz Workbench components.  This allows the Topaz API to be used in non-eclipse based applications like CLIs or web based applications.  
+* A base [Topaz API](./topaz_api.md) that provides APIs to access the mainframe with no dependencies on Topaz Workbench components.  This allows the Topaz API to be used in non-eclipse based applications like CLIs or web based applications.  
 * The Topaz Workbench API provides access Host Connections configured in Topaz Workbench as well Topaz Workbench Host Connection Login dialog.  This allows eclipse plugins to be seemlessly integrated into Topaz Workbench.  
 
 For information about **migrating from the pre-19.5.1 release** of the now depreciated Host Services API to the new APIs, please see the [Migrating from Host Services to Topaz APIs](#migrating-from-host-services-api-to-topaz-apis) section.


### PR DESCRIPTION
Fixed broken links that were caused by refactoring done 15 months ago.