### PR TITLE
Update to remove invalid ISPW event names

### DIFF
--- a/docs/tool_configuration/webhook_setup.md
+++ b/docs/tool_configuration/webhook_setup.md
@@ -75,11 +75,7 @@ The example uses levels `DEV1`, `DEV2`, `DEV3`, with the life cycle for the appl
 
 One or more events during the operation(s) that trigger the webhook. Events can be:
 
-- `Always`
-- `Executing`
-- `Dispatched`
-- `Ready`
-- `Closed`
+- `Approve`
 - `Completed`
 - `Failed`
 - `Terminated`


### PR DESCRIPTION
Remove 5 events listed that ISPW does not support; Always, Executing, Dispatched, Ready, and Closed.  Add one new one: Approve